### PR TITLE
Refactored SamlIdp::Controller to remove whitespace from xml

### DIFF
--- a/lib/saml_idp/controller.rb
+++ b/lib/saml_idp/controller.rb
@@ -3,9 +3,8 @@ module SamlIdp
     require 'openssl'
     require 'base64'
     require 'time'
-    require 'securerandom'
 
-    attr_accessor :x509_certificate, :secret_key, :algorithm, :expires_in
+    attr_accessor :x509_certificate, :secret_key, :algorithm
     attr_accessor :saml_acs_url
 
     def x509_certificate
@@ -42,11 +41,6 @@ module SamlIdp
       algorithm.to_s.split('::').last.downcase
     end
 
-    def expires_in
-      return @expires_in if defined?(@expires_in)
-      @expires_in = SamlIdp.config.expires_in
-    end
-
     protected
 
       def validate_saml_request(saml_request = params[:SAMLRequest])
@@ -69,24 +63,70 @@ module SamlIdp
         issuer_uri = opts[:issuer_uri] || (defined?(request) && request.url) || "http://example.com"
         attributes_statement = attributes(opts[:attributes_provider], nameID)
 
-        session_expiration = ''
-        if expires_in
-          session_expiration = %{ SessionNotOnOrAfter="#{(now + expires_in).iso8601}"}
-        end
+        assertion = <<-XML.gsub(/\n\t/, " ").gsub(/>\s*</, "><")
+          <saml2:Assertion xmlns:saml2="urn:oasis:names:tc:SAML:2.0:assertion" ID="_#{reference_id}" IssueInstant="#{now.iso8601}" Version="2.0">
+            <saml2:Issuer Format="urn:oasis:names:tc:SAML:2.0:nameid-format:entity">#{issuer_uri}</saml2:Issuer>
+            <saml2:Subject>
+              <saml2:NameID Format="urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress">#{nameID}</saml2:NameID>
+              <saml2:SubjectConfirmation Method="urn:oasis:names:tc:SAML:2.0:cm:bearer">
+              <saml2:SubjectConfirmationData#{@saml_request_id.present? ? %[ InResponseTo="#{@saml_request_id}"] : ""} NotOnOrAfter="#{(now+3*60).iso8601}" Recipient="#{@saml_acs_url}">
+              </saml2:SubjectConfirmationData>
+              </saml2:SubjectConfirmation>
+            </saml2:Subject>
+            <saml2:Conditions NotBefore="#{(now-5).iso8601}" NotOnOrAfter="#{(now+60*60).iso8601}">
+              <saml2:AudienceRestriction>
+                <saml2:Audience>#{audience_uri}</saml2:Audience>
+              </saml2:AudienceRestriction>
+            </saml2:Conditions>
+            #{attributes_statement}
+            <saml2:AuthnStatement AuthnInstant="#{now.iso8601}" SessionIndex="_#{reference_id}">
+              <saml2:AuthnContext>
+                <saml2:AuthnContextClassRef>urn:federation:authentication:windows</saml2:AuthnContextClassRef>
+              </saml2:AuthnContext>
+            </saml2:AuthnStatement>
+          </saml2:Assertion>
+        XML
 
-        assertion = %[<saml:Assertion xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" ID="_#{reference_id}" IssueInstant="#{now.iso8601}" Version="2.0"><saml:Issuer Format="urn:oasis:names:SAML:2.0:nameid-format:entity">#{issuer_uri}</saml:Issuer><saml:Subject><saml:NameID Format="urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress">#{nameID}</saml:NameID><saml:SubjectConfirmation Method="urn:oasis:names:tc:SAML:2.0:cm:bearer"><saml:SubjectConfirmationData#{@saml_request_id ? %[ InResponseTo="#{@saml_request_id}"] : ""} NotOnOrAfter="#{(now+3*60).iso8601}" Recipient="#{@saml_acs_url}"></saml:SubjectConfirmationData></saml:SubjectConfirmation></saml:Subject><saml:Conditions NotBefore="#{(now-5).iso8601}" NotOnOrAfter="#{(now+60*60).iso8601}"><saml:AudienceRestriction><saml:Audience>#{audience_uri}</saml:Audience></saml:AudienceRestriction></saml:Conditions>#{attributes_statement}<saml:AuthnStatement AuthnInstant="#{now.iso8601}" SessionIndex="_#{reference_id}"#{session_expiration}><saml:AuthnContext><saml:AuthnContextClassRef>urn:federation:authentication:windows</saml:AuthnContextClassRef></saml:AuthnContext></saml:AuthnStatement></saml:Assertion>]
+        digest_value = Base64.encode64(algorithm.digest(assertion.strip)).gsub(/\n/, '')
 
-        digest_value = Base64.encode64(algorithm.digest(assertion)).gsub(/\n/, '')
+        signed_info = <<-XML.gsub(/\n\t/, " ").gsub(/>\s*</, "><")
+          <ds:SignedInfo xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
+            <ds:CanonicalizationMethod Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"></ds:CanonicalizationMethod>
+            <ds:SignatureMethod Algorithm="http://www.w3.org/2000/09/xmldsig#rsa-#{algorithm_name}"></ds:SignatureMethod>
+            <ds:Reference URI="#_#{reference_id}">
+              <ds:Transforms>
+                <ds:Transform Algorithm="http://www.w3.org/2000/09/xmldsig#enveloped-signature"></ds:Transform>
+                <ds:Transform Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"></ds:Transform>
+              </ds:Transforms>
+              <ds:DigestMethod Algorithm="http://www.w3.org/2000/09/xmldsig##{algorithm_name}"></ds:DigestMethod>
+              <ds:DigestValue>#{digest_value}</ds:DigestValue>
+            </ds:Reference>
+          </ds:SignedInfo>
+        XML
 
-        signed_info = %[<ds:SignedInfo xmlns:ds="http://www.w3.org/2000/09/xmldsig#"><ds:CanonicalizationMethod Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"></ds:CanonicalizationMethod><ds:SignatureMethod Algorithm="http://www.w3.org/2000/09/xmldsig#rsa-#{algorithm_name}"></ds:SignatureMethod><ds:Reference URI="#_#{reference_id}"><ds:Transforms><ds:Transform Algorithm="http://www.w3.org/2000/09/xmldsig#enveloped-signature"></ds:Transform><ds:Transform Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"></ds:Transform></ds:Transforms><ds:DigestMethod Algorithm="http://www.w3.org/2000/09/xmldsig##{algorithm_name}"></ds:DigestMethod><ds:DigestValue>#{digest_value}</ds:DigestValue></ds:Reference></ds:SignedInfo>]
+        signature_value = sign(signed_info.strip).gsub(/\n/, '')
 
-        signature_value = sign(signed_info).gsub(/\n/, '')
+        signature = <<-XML.gsub(/\n\t/, " ").gsub(/>\s*</, "><")
+          <ds:Signature xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
+            #{signed_info}
+            <ds:SignatureValue>#{signature_value}</ds:SignatureValue>
+            <KeyInfo xmlns="http://www.w3.org/2000/09/xmldsig#">
+              <ds:X509Data><ds:X509Certificate>#{self.x509_certificate}</ds:X509Certificate></ds:X509Data>
+            </KeyInfo>
+          </ds:Signature>
+        XML
 
-        signature = %[<ds:Signature xmlns:ds="http://www.w3.org/2000/09/xmldsig#">#{signed_info}<ds:SignatureValue>#{signature_value}</ds:SignatureValue><KeyInfo xmlns="http://www.w3.org/2000/09/xmldsig#"><ds:X509Data><ds:X509Certificate>#{self.x509_certificate}</ds:X509Certificate></ds:X509Data></KeyInfo></ds:Signature>]
+        assertion_and_signature = assertion.sub(/Issuer\>\<saml2:Subject/, "Issuer>#{signature}<saml2:Subject")
 
-        assertion_and_signature = assertion.sub(/Issuer\>\<saml:Subject/, "Issuer>#{signature}<saml:Subject")
-
-        xml = %[<samlp:Response ID="_#{response_id}" Version="2.0" IssueInstant="#{now.iso8601}" Destination="#{@saml_acs_url}" Consent="urn:oasis:names:tc:SAML:2.0:consent:unspecified"#{@saml_request_id ? %[ InResponseTo="#{@saml_request_id}"] : ""} xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol"><saml:Issuer xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion">#{issuer_uri}</saml:Issuer><samlp:Status><samlp:StatusCode Value="urn:oasis:names:tc:SAML:2.0:status:Success" /></samlp:Status>#{assertion_and_signature}</samlp:Response>]
+        xml = <<-XML.gsub(/\n\t/, " ").gsub(/>\s*</, "><")
+          <saml2p:Response Version="2.0" IssueInstant="#{now.iso8601}" Destination="#{@saml_acs_url}" xmlns:saml2p="urn:oasis:names:tc:SAML:2.0:protocol" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+            <saml2:Issuer>"#{issuer_uri}"</saml2:Issuer>
+            <saml2p:Status>
+              <saml2p:StatusCode Value="urn:oasis:names:tc:SAML:2.0:status:Success" />
+            </saml2p:Status>
+            #{assertion_and_signature}
+          </saml2p:Response>
+        XML
 
         Base64.encode64(xml)
       end
@@ -99,7 +139,7 @@ module SamlIdp
       end
 
       def attributes(provider, nameID)
-        provider ? provider : %[<saml:AttributeStatement><saml:Attribute Name="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress"><saml:AttributeValue>#{nameID}</saml:AttributeValue></saml:Attribute></saml:AttributeStatement>]
+        provider ? provider : %[<saml2:AttributeStatement><saml2:Attribute Name="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress"><saml2:AttributeValue>#{nameID}</saml2:AttributeValue></saml2:Attribute></saml2:AttributeStatement>]
       end
   end
 end


### PR DESCRIPTION
Necessary to avoid errors on generation of `digest_value` and on cert
verification.