### PR TITLE
Updated Gemspec to remove executables

### DIFF
--- a/ruby-saml-idp.gemspec
+++ b/ruby-saml-idp.gemspec
@@ -19,8 +19,6 @@ Gem::Specification.new do |s|
      "Gemfile",
      "ruby-saml-idp.gemspec"
   ]
-  s.test_files = `git ls-files -- {test,spec,features}/*`.split("\n")
-  s.executables = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
   s.rdoc_options = ["--charset=UTF-8"]
   s.add_development_dependency("rake")


### PR DESCRIPTION
I'm getting an error trying to run executables the app that uses this gem.
No idea why, just trying something.

`can't find executable yarn for gem ruby-saml-idp`